### PR TITLE
Various improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleGA"
 uuid = "6f159fe9-4850-48a0-97c4-7cf487b3e6ea"
 authors = ["Monumo Ltd.", "Tom Gillam <tpgillam@googlemail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -9,12 +9,16 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
+Aqua = "0.8"
+LinearAlgebra = "1"
 SparseArrays = "1"
 StaticArrays = "1"
+Test = "1"
 julia = "1.6"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Aqua", "Test"]

--- a/src/core20.jl
+++ b/src/core20.jl
@@ -21,9 +21,12 @@ end
 function Base.promote_rule(::Type{Odd{S}}, ::Type{Odd{T}}) where {S<:Real,T<:Real}
     return Odd{promote_type(S, T)}
 end
-Base.zero(a::Even) = Even(zero(a.c1))
-Base.zero(a::Odd) = Odd(zero(a.c1))
-Base.one(a::Even) = Even(one(a.c1))
+Base.zero(::Type{Even{T}}) where {T} = Even(zero(Complex{T}))
+Base.zero(::Type{Odd{T}}) where {T} = Odd(zero(Complex{T}))
+Base.one(::Type{Even{T}}) where {T} = Even(one(Complex{T}))
+Base.zero(a::Even) = zero(typeof(a))
+Base.zero(a::Odd) = zero(typeof(a))
+Base.one(a::Even) = one(typeof(a))
 
 #Addition / subtraction
 Base.:(-)(a::Even) = Even(-a.c1)

--- a/src/core20.jl
+++ b/src/core20.jl
@@ -72,6 +72,8 @@ SimpleGA.project(a::Odd, n::Integer) = n == 1 ? a : zero(a)
 LinearAlgebra.tr(a::Even) = real(a.c1)
 LinearAlgebra.dot(a::Even, b::Even) = real(a.c1 * b.c1)
 LinearAlgebra.dot(a::Odd, b::Odd) = real(conj(a.c1) * b.c1)
+LinearAlgebra.norm(a::Even) = sqrt(abs(dot(a, a)))
+LinearAlgebra.norm(a::Odd) = sqrt(abs(dot(a, a)))
 
 #Exponentiation
 Base.exp(a::Even) = Even(exp(a.c1))

--- a/src/core24.jl
+++ b/src/core24.jl
@@ -31,9 +31,12 @@ function Base.promote_rule(::Type{Odd{S}}, ::Type{Odd{T}}) where {S<:Real,T<:Rea
     return Odd{promote_type(S, T)}
 end
 
-Base.zero(a::Even) = Even(zero(a.m))
-Base.zero(a::Odd) = Odd(zero(a.m))
-Base.one(a::Even) = Even(one(a.m))
+Base.zero(::Type{Even{T}}) where {T} = Even(zero(SMatrix{4,4,Complex{T},16}))
+Base.zero(::Type{Odd{T}}) where {T} = Odd(zero(SMatrix{4,4,Complex{T},16}))
+Base.one(::Type{Even{T}}) where {T} = Even(one(SMatrix{4,4,Complex{T},16}))
+Base.zero(a::Even) = zero(typeof(a))
+Base.zero(a::Odd) = zero(typeof(a))
+Base.one(a::Even) = one(typeof(a))
 
 #Addition / subtraction
 Base.:(-)(a::Even) = Even(-a.m)

--- a/src/core24.jl
+++ b/src/core24.jl
@@ -110,6 +110,8 @@ function LinearAlgebra.dot(a::Odd, b::Odd)
     tmp = real(tr(a.m * g2.m * conj(b.m) * g2.m))
     return convert(typeof(tmp), tmp / 4)
 end
+LinearAlgebra.norm(a::Even) = sqrt(abs(dot(a, a)))
+LinearAlgebra.norm(a::Odd) = sqrt(abs(dot(a, a)))
 
 #Exponentiation
 Base.exp(a::Even) = Even(exp(a.m))

--- a/src/core30.jl
+++ b/src/core30.jl
@@ -121,6 +121,8 @@ end
 LinearAlgebra.tr(a::Even) = a.w
 LinearAlgebra.dot(a::Even, b::Even) = a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z
 LinearAlgebra.dot(a::Odd, b::Odd) = -a.w * b.w + a.x * b.x + a.y * b.y + a.z * b.z
+LinearAlgebra.norm(a::Even) = sqrt(abs(dot(a, a)))
+LinearAlgebra.norm(a::Odd) = sqrt(abs(dot(a, a)))
 
 # Exponentiation
 function SimpleGA.bivector_exp(a::Even)

--- a/src/core30.jl
+++ b/src/core30.jl
@@ -33,9 +33,12 @@ end
 function Base.promote_rule(::Type{Odd{S}}, ::Type{Odd{T}}) where {S<:Real,T<:Real}
     return Odd{promote_type(S, T)}
 end
-Base.zero(a::Even) = Even(zero(a.w), zero(a.x), zero(a.y), zero(a.z))
-Base.zero(a::Odd) = Odd(zero(a.w), zero(a.x), zero(a.y), zero(a.z))
-Base.one(a::Even) = Even(one(a.w), zero(a.x), zero(a.y), zero(a.z))
+Base.zero(::Type{Even{T}}) where {T} = Even(zero(T), zero(T), zero(T), zero(T))
+Base.zero(::Type{Odd{T}}) where {T} = Odd(zero(T), zero(T), zero(T), zero(T))
+Base.one(::Type{Even{T}}) where {T} = Even(one(T), zero(T), zero(T), zero(T))
+Base.zero(a::Even) = zero(typeof(a))
+Base.zero(a::Odd) = zero(typeof(a))
+Base.one(a::Even) = one(typeof(a))
 
 # Addition / subtraction
 Base.:(-)(a::Even) = Even(-a.w, -a.x, -a.y, -a.z)

--- a/src/core31.jl
+++ b/src/core31.jl
@@ -159,6 +159,8 @@ function LinearAlgebra.dot(a::Odd, b::Odd)
     )
     return convert(typeof(tmp), tmp / 2)
 end
+LinearAlgebra.norm(a::Even) = sqrt(abs(dot(a, a)))
+LinearAlgebra.norm(a::Odd) = sqrt(abs(dot(a, a)))
 
 #Exponentiation
 function SimpleGA.bivector_exp(a::Even)

--- a/src/core31.jl
+++ b/src/core31.jl
@@ -45,9 +45,22 @@ function Base.promote_rule(::Type{Odd{S}}, ::Type{Odd{T}}) where {S<:Real,T<:Rea
     return Odd{promote_type(S, T)}
 end
 
-Base.zero(a::Even) = Even(zero(a.c1), zero(a.c2), zero(a.c3), zero(a.c4))
-Base.zero(a::Odd) = Odd(zero(a.c1), zero(a.c2), zero(a.c3), zero(a.c4))
-Base.one(a::Even) = Even(one(a.c1), zero(a.c2), zero(a.c3), one(a.c4))
+function Base.zero(::Type{Even{T}}) where {T}
+    z = zero(Complex{T})
+    return Even(z, z, z, z)
+end
+function Base.zero(::Type{Odd{T}}) where {T}
+    z = zero(Complex{T})
+    return Odd(z, z, z, z)
+end
+function Base.one(::Type{Even{T}}) where {T}
+    o = one(Complex{T})
+    z = zero(Complex{T})
+    return Even(o, z, z, o)
+end
+Base.zero(a::Even) = zero(typeof(a))
+Base.zero(a::Odd) = zero(typeof(a))
+Base.one(a::Even) = one(typeof(a))
 
 #Addition / subtraction
 Base.:(-)(a::Even) = Even(-a.c1, -a.c2, -a.c3, -a.c4)

--- a/src/core3232.jl
+++ b/src/core3232.jl
@@ -34,8 +34,10 @@ function Base.promote_rule(
     return Multivector{promote_type(S, T)}
 end
 
-Base.zero(a::Multivector) = Multivector([basscl], [zero(a.val[1])])
-Base.one(a::Multivector) = Multivector([basscl], [one(a.val[1])])
+Base.zero(::Type{Multivector{T}}) where {T} = Multivector([basscl], [zero(T)])
+Base.one(::Type{Multivector{T}}) where {T} = Multivector([basscl], [one(T)])
+Base.zero(a::Multivector) = zero(typeof(a))
+Base.one(a::Multivector) = one(typeof(a))
 
 #This avoids rounding error bloating multivectors. Set of FP64
 const mvtol = 1e-14

--- a/src/core3232.jl
+++ b/src/core3232.jl
@@ -175,6 +175,7 @@ function LinearAlgebra.dot(mv1::Multivector, mv2::Multivector)
     end
     return res
 end
+LinearAlgebra.norm(a::Multivector) = sqrt(abs(dot(a, a)))
 
 #Exponentiation
 function Base.exp(a::Multivector)

--- a/src/core33.jl
+++ b/src/core33.jl
@@ -124,6 +124,8 @@ function LinearAlgebra.dot(a::Odd, b::Odd)
     tmp = tr(a.p * b.m) + tr(a.m * b.p)
     return convert(typeof(tmp), tmp / 8)
 end
+LinearAlgebra.norm(a::Even) = sqrt(abs(dot(a, a)))
+LinearAlgebra.norm(a::Odd) = sqrt(abs(dot(a, a)))
 
 #Exponentiation
 Base.exp(a::Even) = Even(exp(a.p), exp(a.m))

--- a/src/core33.jl
+++ b/src/core33.jl
@@ -31,9 +31,21 @@ function Base.promote_rule(::Type{Odd{S}}, ::Type{Odd{T}}) where {S<:Real,T<:Rea
     return Odd{promote_type(S, T)}
 end
 
-Base.zero(a::Even) = Even(zero(a.p), zero(a.m))
-Base.zero(a::Odd) = Odd(zero(a.p), zero(a.m))
-Base.one(a::Even) = Even(one(a.p), one(a.m))
+function Base.zero(::Type{Even{T}}) where {T}
+    z = zero(SMatrix{4,4,T,16})
+    return Even(z, z)
+end
+function Base.zero(::Type{Odd{T}}) where {T}
+    z = zero(SMatrix{4,4,T,16})
+    return Odd(z, z)
+end
+function Base.one(::Type{Even{T}}) where {T}
+    o = one(SMatrix{4,4,T,16})
+    return Even(o, o)
+end
+Base.zero(a::Even) = zero(typeof(a))
+Base.zero(a::Odd) = zero(typeof(a))
+Base.one(a::Even) = one(typeof(a))
 
 #Addition / subtraction
 Base.:(-)(a::Even) = Even(-a.p, -a.m)

--- a/src/core40.jl
+++ b/src/core40.jl
@@ -5,8 +5,6 @@ Work using self-dual and anti-self-dual decomposition, so just use a pair of qua
 Useful algebra for projective geometry.
 """
 
-using ..Quaternions
-
 struct Even{T<:Real} <: Number
     qp::Quaternion{T}
     qm::Quaternion{T}
@@ -30,9 +28,12 @@ function Base.promote_rule(::Type{Odd{S}}, ::Type{Odd{T}}) where {S<:Real,T<:Rea
     return Odd{promote_type(S, T)}
 end
 
-Base.zero(a::Even) = Even(zero(a.qp), zero(a.qm))
-Base.zero(a::Odd) = Odd(zero(a.qp), zero(a.qm))
-Base.one(a::Even) = Even(one(a.qp), one(a.qm))
+Base.zero(::Type{Even{T}}) where {T} = Even(zero(Quaternion{T}), zero(Quaternion{T}))
+Base.zero(::Type{Odd{T}}) where {T} = Odd(zero(Quaternion{T}), zero(Quaternion{T}))
+Base.one(::Type{Even{T}}) where {T} = Even(one(Quaternion{T}), one(Quaternion{T}))
+Base.zero(a::Even) = zero(typeof(a))
+Base.zero(a::Odd) = zero(typeof(a))
+Base.one(a::Even) = one(typeof(a))
 
 #Addition / subtraction
 Base.:(-)(a::Even) = Even(-a.qp, -a.qm)

--- a/src/core40.jl
+++ b/src/core40.jl
@@ -101,6 +101,9 @@ function LinearAlgebra.dot(a::Odd, b::Odd)
     return convert(typeof(tmp), tmp / 2)
 end
 
+LinearAlgebra.norm(a::Even) = sqrt(abs(dot(a, a)))
+LinearAlgebra.norm(a::Odd) = sqrt(abs(dot(a, a)))
+
 #Exponentiation
 SimpleGA.bivector_exp(a::Even) = Even(bivector_exp(a.qp), bivector_exp(a.qm))
 

--- a/src/core44.jl
+++ b/src/core44.jl
@@ -40,8 +40,10 @@ function Base.promote_rule(
 ) where {S<:Real,T<:Real}
     return Multivector{promote_type(S, T)}
 end
-Base.zero(a::Multivector) = Multivector([0x00], [zero(a.val[1])])
-Base.one(a::Multivector) = Multivector([0x00], [one(a.val[1])])
+Base.zero(::Type{Multivector{T}}) where {T} = Multivector([0x00], [zero(T)])
+Base.one(::Type{Multivector{T}}) where {T} = Multivector([0x00], [one(T)])
+Base.zero(a::Multivector) = zero(typeof(a))
+Base.one(a::Multivector) = one(typeof(a))
 
 #Addition / subtraction
 Base.:(-)(mv::Multivector) = Multivector(mv.bas, -mv.val)

--- a/src/core44.jl
+++ b/src/core44.jl
@@ -141,6 +141,7 @@ function LinearAlgebra.dot(mv1::Multivector, mv2::Multivector)
     end
     return res
 end
+LinearAlgebra.norm(a::Multivector) = sqrt(abs(dot(a, a)))
 
 #Exponentiation
 function Base.exp(a::Multivector)

--- a/src/corecga.jl
+++ b/src/corecga.jl
@@ -20,9 +20,22 @@ end
 Even(q1, q2, q3, q4) = Even(promote(q1, q2, q3, q4)...)
 Odd(q1, q2, q3, q4) = Odd(promote(q1, q2, q3, q4)...)
 
-Base.zero(a::Even) = Even(zero(a.q1), zero(a.q1), zero(a.q1), zero(a.q1))
-Base.zero(a::Odd) = Odd(zero(a.q1), zero(a.q1), zero(a.q1), zero(a.q1))
-Base.one(a::Even) = Even(one(a.q1), zero(a.q1), zero(a.q1), one(a.q1))
+function Base.zero(::Type{Even{T}}) where {T}
+    z = zero(Quaternion{T})
+    return Even(z, z, z, z)
+end
+function Base.zero(::Type{Odd{T}}) where {T}
+    z = zero(Quaternion{T})
+    return Odd(z, z, z, z)
+end
+function Base.one(::Type{Even{T}}) where {T}
+    o = one(Quaternion{T})
+    z = zero(Quaternion{T})
+    return Even(o, z, z, o)
+end
+Base.zero(a::Even) = zero(typeof(a))
+Base.zero(a::Odd) = zero(typeof(a))
+Base.one(a::Even) = one(typeof(a))
 
 function Base.convert(::Type{Even{T}}, a::Even) where {T<:Real}
     return Even{T}(

--- a/src/corecga.jl
+++ b/src/corecga.jl
@@ -162,6 +162,8 @@ function LinearAlgebra.dot(a::Odd, b::Odd)
     tmp = -(dot(a.q1, b.q1) - dot(a.q2, b.q3) + dot(a.q4, b.q4) - dot(a.q3, b.q2))
     return convert(typeof(tmp), tmp / 2)
 end
+LinearAlgebra.norm(a::Even) = sqrt(abs(dot(a, a)))
+LinearAlgebra.norm(a::Odd) = sqrt(abs(dot(a, a)))
 
 #Exponentiation
 #Uses a simple scale and square implementation.

--- a/src/corepga.jl
+++ b/src/corepga.jl
@@ -89,6 +89,8 @@ end
 LinearAlgebra.tr(a::Even) = a.q.w
 LinearAlgebra.dot(a::Even, b::Even) = dot(a.q, b.q)
 LinearAlgebra.dot(a::Odd, b::Odd) = -dot(a.q, b.q)
+LinearAlgebra.norm(a::Even) = sqrt(abs(dot(a, a)))
+LinearAlgebra.norm(a::Odd) = sqrt(abs(dot(a, a)))
 
 #Exponentiation
 function SimpleGA.bivector_exp(a::Even)

--- a/src/corepga.jl
+++ b/src/corepga.jl
@@ -32,9 +32,12 @@ function Base.promote_rule(::Type{Odd{S}}, ::Type{Odd{T}}) where {S<:Real,T<:Rea
     return Odd{promote_type(S, T)}
 end
 
-Base.zero(a::Even) = Even(zero(a.q), zero(a.n))
-Base.zero(a::Odd) = Odd(zero(a.q), zero(a.n))
-Base.one(a::Even) = Even(one(a.q), zero(a.n))
+Base.zero(::Type{Even{T}}) where {T} = Even(zero(Quaternion{T}), zero(Quaternion{T}))
+Base.zero(::Type{Odd{T}}) where {T} = Odd(zero(Quaternion{T}), zero(Quaternion{T}))
+Base.one(::Type{Even{T}}) where {T} = Even(one(Quaternion{T}), zero(Quaternion{T}))
+Base.zero(a::Even) = zero(typeof(a))
+Base.zero(a::Odd) = zero(typeof(a))
+Base.one(a::Even) = one(typeof(a))
 
 #Addition / subtraction
 Base.:(-)(a::Even) = Even(-a.q, -a.n)

--- a/src/coresta.jl
+++ b/src/coresta.jl
@@ -46,9 +46,22 @@ function Base.promote_rule(::Type{Odd{S}}, ::Type{Odd{T}}) where {S<:Real,T<:Rea
     return Odd{promote_type(S, T)}
 end
 
-Base.zero(a::Even) = Even(zero(a.c1), zero(a.c2), zero(a.c3), zero(a.c4))
-Base.zero(a::Odd) = Odd(zero(a.c1), zero(a.c2), zero(a.c3), zero(a.c4))
-Base.one(a::Even) = Even(one(a.c1), zero(a.c2), zero(a.c3), one(a.c4))
+function Base.zero(::Type{Even{T}}) where {T}
+    z = zero(Complex{T})
+    return Even(z, z, z, z)
+end
+function Base.zero(::Type{Odd{T}}) where {T}
+    z = zero(Complex{T})
+    return Odd(z, z, z, z)
+end
+function Base.one(::Type{Even{T}}) where {T}
+    o = one(Complex{T})
+    z = zero(Complex{T})
+    return Even(o, z, z, o)
+end
+Base.zero(a::Even) = zero(typeof(a))
+Base.zero(a::Odd) = zero(typeof(a))
+Base.one(a::Even) = one(typeof(a))
 
 #Addition / subtraction
 Base.:(-)(a::Even) = Even(-a.c1, -a.c2, -a.c3, -a.c4)

--- a/src/coresta.jl
+++ b/src/coresta.jl
@@ -162,6 +162,8 @@ function LinearAlgebra.dot(a::Odd, b::Odd)
     )
     return convert(typeof(tmp), tmp / 2)
 end
+LinearAlgebra.norm(a::Even) = sqrt(abs(dot(a, a)))
+LinearAlgebra.norm(a::Odd) = sqrt(abs(dot(a, a)))
 
 #Exponentiation
 function SimpleGA.bivector_exp(a::Even)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 #Test suite for Geometric Algebra
 
+using Aqua
 using SimpleGA
 using LinearAlgebra
 using Test
@@ -7,6 +8,15 @@ using Test
 include("testfuncs.jl")
 
 @testset "GA Tests" begin
+    @testset "aqua" begin
+        # NOTE: We run ambiguities separately, since we _only_ want to include methods in this
+        #   package. See the discussion in this thread:
+        #       https://discourse.julialang.org/t/aqua-jl-finds-many-ambiguities-in-core-base/103963
+        #   By passing only our own package, we skip quite a bit of noise from upstream.
+        Aqua.test_all(SimpleGA; ambiguities=false)
+        Aqua.detect_ambiguities(SimpleGA)
+    end
+
     #! format: off
     @testset "GA(2, 0)" begin include("test20.jl") end
     @testset "GA(3, 0)" begin include("test30.jl") end

--- a/test/test20.jl
+++ b/test/test20.jl
@@ -1,6 +1,8 @@
 # Test suite for GA 20.
 # Test stand-alone results and compares with GA(4,4)
 
+test_type(GA20.Even, GA20.Odd)
+
 bas20 = GA20.basis
 e1 = bas20[1]
 e2 = bas20[2]

--- a/test/test24.jl
+++ b/test/test24.jl
@@ -1,6 +1,8 @@
 #Test suite for GA(2,4).
 #Test stand-alone results and compares with GA(2,4)
 
+test_type(GA24.Even, GA24.Odd)
+
 bas24 = GA24.basis
 (g0, g1, g2, g3, g4, g5) = (bas24[1], bas24[2], bas24[3], bas24[4], bas24[5], bas24[6])
 

--- a/test/test30.jl
+++ b/test/test30.jl
@@ -1,6 +1,8 @@
 #Test suite for GA(3,0).
 #Test stand-alone results and compares with GA(4,4)
 
+test_type(GA30.Even, GA30.Odd)
+
 bas30 = GA30.basis
 e1 = bas30[1]
 e2 = bas30[2]

--- a/test/test31.jl
+++ b/test/test31.jl
@@ -1,6 +1,8 @@
 #Test suite for GA31.
 #Test stand-alone results and compares with GA(4,4)
 
+test_type(GA31.Even, GA31.Odd)
+
 basGA31 = GA31.basis
 (e1, e2, e3, f3) = (basGA31[1], basGA31[2], basGA31[3], basGA31[4])
 I4 = e1 * e2 * e3 * f3

--- a/test/test3232.jl
+++ b/test/test3232.jl
@@ -1,6 +1,8 @@
 #Tests of GA(32,32)
 #Full fat products are slow in this algebra, so test with random subsets
 
+test_type(GA3232.Multivector, GA3232.Multivector)
+
 bas64 = GA3232.basis
 #! format:off
 @test map(x->dot(x,x), bas64) == [  1,-1,1,-1,1,-1,1,-1,

--- a/test/test33.jl
+++ b/test/test33.jl
@@ -1,6 +1,8 @@
 #Test suite for GA(3,3).
 #Test stand-alone results and compares with GA(4,4)
 
+test_type(GA33.Even, GA33.Odd)
+
 bas33 = GA33.basis
 (e1, e2, e3, f1, f2, f3) = (bas33[1], bas33[2], bas33[3], bas33[4], bas33[5], bas33[6])
 

--- a/test/test40.jl
+++ b/test/test40.jl
@@ -1,6 +1,8 @@
 #Test suite for GA(4,0).
 #Test stand-alone results and compares with GA(4,4)
 
+test_type(GA40.Even, GA40.Odd)
+
 bas40 = GA40.basis
 (e1, e2, e3, e4) = (bas40[1], bas40[2], bas40[3], bas40[4])
 E4 = e1 * e2 * e3 * e4

--- a/test/test44.jl
+++ b/test/test44.jl
@@ -1,6 +1,8 @@
 #Stand-alone tests of GA(4,4)
 #All other algebras are compared to this.
 
+test_type(GA44.Multivector, GA44.Multivector)
+
 bas44 = GA44.basis
 @test map(x -> dot(x, x), bas44) == [1, 1, 1, 1, -1, -1, -1, -1]
 run_basis_tests(bas44)

--- a/test/testCGA.jl
+++ b/test/testCGA.jl
@@ -1,6 +1,8 @@
 #Test suite for CGA.
 #Test stand-alone results and compares with GA(4,4)
 
+test_type(CGA.Even, CGA.Odd)
+
 basCGA = CGA.basis
 (e1, e2, e3, e4, f4) = (basCGA[1], basCGA[2], basCGA[3], basCGA[4], basCGA[5])
 I5 = e1 * e2 * e3 * e4 * f4

--- a/test/testPGA.jl
+++ b/test/testPGA.jl
@@ -1,6 +1,8 @@
 #Test suite for PGA.
 #Test stand-alone results and compares with GA(4,4)
 
+test_type(PGA.Even, PGA.Odd)
+
 basPGA = PGA.basis
 (e1, e2, e3, e0) = (basPGA[1], basPGA[2], basPGA[3], basPGA[4])
 @test map(x -> dot(x, x), basPGA) == [1, 1, 1, 0]

--- a/test/testSTA.jl
+++ b/test/testSTA.jl
@@ -1,6 +1,8 @@
 #Test suite for STA.
 #Test STAnd-alone results and compares with GA(4,4)
 
+test_type(STA.Even, STA.Odd)
+
 basSTA = STA.basis
 (g0, g1, g2, g3) = g0 = (basSTA[1], basSTA[2], basSTA[3], basSTA[4])
 I4 = g0 * g1 * g2 * g3

--- a/test/testfuncs.jl
+++ b/test/testfuncs.jl
@@ -78,7 +78,7 @@ function test_type(Even::Type, Odd::Type)
 
     be = one(Even{Int8})
     # NB: There is no concept of "one" for Odd multivectors
-    
+
     # arrays of ones and zeros should work too.
     aes = zeros(Even{Int8}, 3, 3)
     @test all(aes .== ae)

--- a/test/testfuncs.jl
+++ b/test/testfuncs.jl
@@ -73,10 +73,13 @@ function test_type(Even::Type, Odd::Type)
     # Scalar construction
     ae = zero(Even{Int8})
     @test zero(ae) == ae
+    @test norm(ae) == 0
     ao = zero(Odd{Int8})
     @test zero(ao) == ao
+    @test norm(ao) == 0
 
     be = one(Even{Int8})
+    @test norm(be) == 1
     # NB: There is no concept of "one" for Odd multivectors
 
     # arrays of ones and zeros should work too.
@@ -91,8 +94,15 @@ end
 
 """Tests that unit vector generators behave correctly over integers"""
 function run_test_positive_norm(e1, e2)
+    @test norm(e1) == 1
+    @test norm(e2) == 1
+    @test norm(10 * e1) == 10
     @test e1 * e1 == one(e1 * e2)
     @test e2 * e2 == one(e2 * e1)
+    @test norm(e1 * e2) == 1
+    @test norm(e2 * e1) == 1
+    @test norm(3.0 * e1 * e2) == 3
+    @test norm(3.0 * e2 * e1) == 3
     @test 1 + e1 * e2 == e1 * e2 + 1
     @test 1 - e1 * e2 == -e1 * e2 + 1
     @test (1 + e1 * e2) * (1 + e1 * e2) == 2 * e1 * e2

--- a/test/testfuncs.jl
+++ b/test/testfuncs.jl
@@ -65,6 +65,30 @@ function run_basis_tests(basis)
     end
 end
 
+"""Run common tests based on a multivector type.
+
+Note that Even and Odd _might_ be the same type.
+"""
+function test_type(Even::Type, Odd::Type)
+    # Scalar construction
+    ae = zero(Even{Int8})
+    @test zero(ae) == ae
+    ao = zero(Odd{Int8})
+    @test zero(ao) == ao
+
+    be = one(Even{Int8})
+    # NB: There is no concept of "one" for Odd multivectors
+    
+    # arrays of ones and zeros should work too.
+    aes = zeros(Even{Int8}, 3, 3)
+    @test all(aes .== ae)
+    aos = zeros(Odd{Int8}, 3, 3)
+    @test all(aos .== ao)
+
+    bes = ones(Even{Int8}, 3, 3)
+    @test all(bes .== be)
+end
+
 """Tests that unit vector generators behave correctly over integers"""
 function run_test_positive_norm(e1, e2)
     @test e1 * e1 == one(e1 * e2)


### PR DESCRIPTION
Closes #21 , #24, #17

The main user-facing change is that we now support calling `zero` on any multivector _type_ (and `one` for even multivectors), and not just on existing values. As a consequence the `zeros` and `ones` functions for intialising arrays will 'just work', as noted in #24 .

We also implement `LinearAlgebra.norm` for all types (although not allowing anything other than `p=2` for now). This is defined in a such a way that the norm will always be real, by taking the square root of the _absolute value_ of the dot product.
